### PR TITLE
Task wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,31 +5,30 @@ on:
   release:
     types:
       - created
+# jobs:
+#   build:
+#     strategy:
+#       matrix:
+#         os: [macos-latest, ubuntu-latest, windows-latest]
+#     runs-on: ${{ matrix.os }}
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v2
+#       - name: Install Node.js
+#         uses: actions/setup-node@v1
+#         with:
+#           node-version: 10.x
+#       - run: npm install
+#       - run: xvfb-run -a npm test
+#         if: runner.os == 'Linux'
+#       - run: npm test
+#         if: runner.os != 'Linux'
 
-jobs:
-  build:
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
-      - run: npm install
-      - run: xvfb-run -a npm test
-        if: runner.os == 'Linux'
-      - run: npm test
-        if: runner.os != 'Linux'
+#       - name: Run a one-line script
+#         run: echo Hello, world ${{ github.ref }}!
 
-      - name: Run a one-line script
-        run: echo Hello, world ${{ github.ref }}!
-
-      - name: Publish
-        if: success() && startsWith( github.ref, 'refs/tags/v') && matrix.os == 'ubuntu-latest'
-        run: npm run deploy
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+#       - name: Publish
+#         if: success() && startsWith( github.ref, 'refs/tags/v') && matrix.os == 'ubuntu-latest'
+#         run: npm run deploy
+#         env:
+#           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor entire code-base
 - Disposal of services
 - Groundwork for multiple instances of the debugger
+
+## [0.2.0] - 2022-03-05
+
+### Added
+
+- Support for `dotnetwatchattach` to manage the lifetime of a specified task by defining the `task` parameter in your launch.json. I no longer advise you to use the `preLaunchTask` and `postLaunchTask` configuration properties. This has the added benefit that the `isBackground: true` property is no longer required for the task definition (fixes [#1](https://github.com/Trottero/dotnet-watch-attach/issues/1)).

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Configuration is simple, you need two tasks: one to start watching and one termi
           "ASPNETCORE_ENVIRONMENT": "Development"
         }
       },
-      "preLaunchTask": "watch",
-      "postDebugTask": "terminatewatch",
+      "task": "watchTaskName", // Label of watch task in tasks.json
       "program": "<startup-project-name>.exe"
     }
   ]
@@ -40,15 +39,6 @@ Configuration is simple, you need two tasks: one to start watching and one termi
 // tasks.json
 {
   "version": "2.0.0",
-  "inputs": [
-    // Little trick to automatically terminate watch task.
-    {
-      "id": "terminatewatchparam",
-      "type": "command",
-      "command": "workbench.action.tasks.terminate",
-      "args": "watch"
-    }
-  ],
   "tasks": [
     {
       "label": "watch",
@@ -61,14 +51,7 @@ Configuration is simple, you need two tasks: one to start watching and one termi
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],
-      "problemMatcher": "$msCompile",
-      "isBackground": true
-    },
-    {
-      "label": "terminatewatch",
-      "type": "shell",
-      "command": "echo ${input:terminatewatchparam}",
-      "problemMatcher": []
+      "problemMatcher": "$msCompile"
     }
   ]
 }
@@ -78,8 +61,6 @@ Configuration is simple, you need two tasks: one to start watching and one termi
 
 ## Known Issues
 
-None yet...
+- There is a race condition where the extension checks if the proces exists, and if it does it will try to start a debug session moments later. If during that time the process is killed (by rebuilding for example) the debugger will fail to attach and terminate.
 
-Please create and issue / PR for any problems you may encounter.
-
----
+Please create an [issue / PR](https://github.com/Trottero/dotnet-watch-attach/issues) for any problems you may encounter.

--- a/package.json
+++ b/package.json
@@ -35,15 +35,22 @@
         "type": "dotnetwatchattach",
         "label": ".NET Watch Attach",
         "configurationAttributes": {
-          "attach": {
+          "launch": {
+            "required": [
+              "program"
+            ],
             "properties": {
               "args": {
                 "type": "object",
-                "Description": "Arguments passed to coreclr attach"
+                "description": "Arguments passed to underlying coreclr attach"
               },
               "program": {
                 "type": "string",
-                "Description": "Name of exe that dotnet attach has to attach to"
+                "description": "Program to attach to. This is usually the name of the startup `.csproj` file with the `.exe` extension appended. \n e.g. to debug the process from `dotnet watch run weather.csproj`, set this to `weather.exe`. Do note that this is different depending on your dotnet version."
+              },
+              "task": {
+                "type": "string",
+                "description": "The label of a dotnet watch task to run as defined in `tasks.json` \n This task will automatically be run when the debug session starts, and terminated when the debug session ends. \n NOTE: It is not required to set `isBackground: true` for this task."
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dotnetwatchattach",
   "displayName": ".NET Watch Attach",
   "description": "Wrapper for coreclr attach which automatically attaches when a given program gets launched by `dotnet watch`.",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "publisher": "Trottero",
   "contributors": [
     {

--- a/src/models/watchAttachDebugConfiguration.ts
+++ b/src/models/watchAttachDebugConfiguration.ts
@@ -2,9 +2,20 @@ import { DebugConfiguration } from 'vscode';
 
 export interface WatchAttachDebugConfiguration extends DebugConfiguration {
   /**
-   * Program to attach to.
+   * Program to attach to. This is usually the name of the startup `.csproj` file with the `.exe` extension appended.
+   *
+   * e.g. to debug the process from `dotnet watch run weather.csproj`, set this to `weather.exe`. Do note that this is different depending
+   * on your dotnet version.
    */
   program: string;
+  /**
+   * The label of a dotnet watch task to run as defined in `tasks.json`
+   *
+   * This task will automatically be run when the debug session starts, and terminated when the debug session ends.
+   *
+   * NOTE: It is not required to set `isBackground: true` for this task.
+   */
+  task: string;
 }
 
 export const WATCH_ATTACH_AUTO_NAME = '.NET Watch Attach (Child attach)';

--- a/src/watchAttach.ts
+++ b/src/watchAttach.ts
@@ -142,7 +142,7 @@ export class WatchAttach implements Disposable {
     vscode.tasks.fetchTasks().then((taskList) => {
       const taskDefinition = taskList.filter((task) => task.name === taskName)?.[0];
       if (!taskDefinition) {
-        // Do some nice error message or something.
+        // Let the user know that the task is not found.
         vscode.window.showErrorMessage(
           `Debugger can not be started, task "${taskName}" not found. Check if it is defined in your tasks.json file.`,
           'Close'

--- a/src/watchAttach.ts
+++ b/src/watchAttach.ts
@@ -27,6 +27,8 @@ export class WatchAttach implements Disposable {
 
   private _session: vscode.DebugSession | null = null;
 
+  private _taskExecution: Thenable<vscode.TaskExecution> | null = null;
+
   private _pollingInterval = 100;
 
   private _tryAttachSubscription: Subscription;
@@ -50,10 +52,18 @@ export class WatchAttach implements Disposable {
 
   public startWatchAttach() {
     const onStartDebug = vscode.debug.onDidStartDebugSession((debugSession) => {
-      if (debugSession.type === 'dotnetwatchattach') {
-        // Upon starting the debug session, store the parent in this service and try to attach a .NET debugger
-        this._session = debugSession;
-        this._tryAttach.next(debugSession);
+      // Only start if it was started by this extension.
+      if (debugSession.type !== 'dotnetwatchattach') {
+        return;
+      }
+
+      // Upon starting the debug session, store the parent in this service and try to attach a .NET debugger
+      this._session = debugSession;
+      this._tryAttach.next(debugSession);
+
+      // If the user has defined a specific task to run, run it.
+      if (this.config.task) {
+        this.startExternalTask(this.config.task);
       }
     });
     this._disposables.push(onStartDebug);
@@ -67,10 +77,18 @@ export class WatchAttach implements Disposable {
           this._tryAttach.next(this._session as vscode.DebugSession);
         }
       }
-      // If parent process was closed
+
+      // If parent process was closed (the user stopped the debug session)
       if (debugSession.type === 'dotnetwatchattach') {
-        debugSession.type;
         this._session = null;
+
+        // Dispose of the task execution if it exists.
+        if (this._taskExecution !== null) {
+          this._taskExecution.then((taskExecution) => {
+            taskExecution.terminate();
+            this._taskExecution = null;
+          });
+        }
       }
     });
     this._disposables.push(onTerminateDebug);
@@ -118,6 +136,23 @@ export class WatchAttach implements Disposable {
       });
       return result.includes(programName);
     }
+  }
+
+  private startExternalTask(taskName: string): void {
+    vscode.tasks.fetchTasks().then((taskList) => {
+      const taskDefinition = taskList.filter((task) => task.name === taskName)?.[0];
+      if (!taskDefinition) {
+        // Do some nice error message or something.
+        vscode.window.showErrorMessage(
+          `Debugger can not be started, task "${taskName}" not found. Check if it is defined in your tasks.json file.`,
+          'Close'
+        );
+        vscode.debug.stopDebugging(this._session as vscode.DebugSession);
+        return;
+      }
+
+      this._taskExecution = vscode.tasks.executeTask(taskDefinition);
+    });
   }
 
   dispose() {


### PR DESCRIPTION
This PR adds support for dotnet-watch-attach to take a task as a parameter. The lifecycle of this task is then managed by the extension which fixes #1 